### PR TITLE
edited setup and zshrc_config

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,17 @@
 
 mkdir -p ~/.config/nvim
 
-ln -s zshrc_config ~/.zshrc
+# Removes user old vim init and symlinks
+rm -rf ~/.config/nvim/init.vim 
+cp vim_config.vim ~/.config/nvim/init.vim
 ln -s vim_config.vim ~/.config/nvim/init.vim
+
+# Removes user old tmux conf and symlinks
+rm -rf ~/.tmux.conf
+cp tmux.conf ~/.tmux.conf
 ln -s tmux.conf ~/.tmux.conf
+
+# Removes user old zshrc and symlinks
+rm -rf ~/.zshrc
+cp zshrc_config ~/.zshrc
+ln -s zshrc_config ~/.zshrc

--- a/zshrc_config
+++ b/zshrc_config
@@ -2,13 +2,13 @@
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
 
 # Path to your oh-my-zsh installation.
-export ZSH="/Users/aaron.cheng/.oh-my-zsh"
+export ZSH="/Users/${USER}/.oh-my-zsh"
 
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
-ZSH_THEME="lambda-mod"
+ZSH_THEME="af-magic"
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load


### PR DESCRIPTION
- I have edited setup.sh to symlink the files properly. 
- I have also edited zshrc_config to be user agnostic for ease of use
- zshrc_config uses af-magic because it ships with oh-my-zsh now